### PR TITLE
as_libxml.c: Set xmlDoc to be of "HTML" type to fix HTML-specific code in libxml2

### DIFF
--- a/src/as-libxml.c
+++ b/src/as-libxml.c
@@ -12,6 +12,7 @@
 #define NEEDS_SANITIZE_NAME 1
 #include "as-libxml.h"
 #include <libxml/tree.h>
+#include <libxml/HTMLtree.h>
 #include <libxml/dict.h>
 
 // Namespace constants, indexed by GumboNamespaceEnum.
@@ -310,7 +311,7 @@ convert_node(xmlDocPtr doc, xmlNodePtr xml_parent, GumboNode* node, GumboElement
 
 static inline xmlDocPtr
 alloc_doc(Options *opts) {
-    xmlDocPtr doc = xmlNewDoc(BAD_CAST "1.0");
+    xmlDocPtr doc = htmlNewDocNoDtD(NULL, NULL);
     if (doc) {
         if (!doc->dict) {
             doc->dict = xmlDictCreate();


### PR DESCRIPTION
Some code paths in libxml2 check whether the passed in document is an HTML document. If parsing HTML with lxml/libxml2, then the xmlDoc has `(doc->type == XML_HTML_DOCUMENT_NODE)` instead of `XML_DOCUMENT_NODE`. Some libxml2 code checks for this property and chooses a different execution path (e.g. see [1]).

My specific problem was that when using lxml's html.tostring method, attribute values containing unicode characters were converted to hexadecimal character references of the form '&#nnnn;' (see [2], in the `else` block). This works fine for anyone viewing the rendered HTML in their browser. But I'd like to preserve the UTF-8 characters, as is the behavior for lxml, so that I can e.g. edit the HTML file in the future.

Consider the following proof of concept:

```python
>>> import html5_parser
>>> from lxml import html
>>> root1 = html5_parser.parse('<meta name="description" content="Sóme UTF-8 chāracterṣ" />')
>>> root2 = html.fromstring('<meta name="description" content="Sóme UTF-8 chāracterṣ" />')
>>> html.tostring(root1, encoding='unicode')
'<html><head><meta name="description" content="S&#xF3;me UTF-8 ch&#x101;racter&#x1E63;"></head><body></body></html>'
>>> html.tostring(root2, encoding='unicode')
'<html><head><meta name="description" content="Sóme UTF-8 chāracterṣ"></head></html>'
```

(Ignore the absence of the `<body/>` element in `root2` parsed by lxml)

After my fix, the output is as follows:

```python
>>> html.tostring(root1, encoding='unicode')
'<html><head><meta name="description" content="Sóme UTF-8 chāracterṣ"></head><body></body></html>'
```

[1]: https://github.com/GNOME/libxml2/blob/e03f0a199a67017b2f8052354cf732b2b4cae787/entities.c#L570
[2]: https://github.com/GNOME/libxml2/blob/e03f0a199a67017b2f8052354cf732b2b4cae787/entities.c#L655