### PR TITLE
as-libxml.c: Set encoding of xmlDoc to UTF-8

### DIFF
--- a/src/as-libxml.c
+++ b/src/as-libxml.c
@@ -320,6 +320,7 @@ alloc_doc(Options *opts) {
             }
             opts->line_number_attr = xmlDictLookup(doc->dict, BAD_CAST opts->line_number_attr, -1);
         }
+	doc->encoding = xmlStrdup(BAD_CAST "UTF-8");
     }
     return doc;
 }


### PR DESCRIPTION
Some parts of libxml2 check the encoding of an xmlDoc to decide how to serialize an element (see e.g. [1]).

See also PR #11, which was not a good solution since it assumes all input to be HTML.

[1]: https://github.com/GNOME/libxml2/blob/e03f0a199a67017b2f8052354cf732b2b4cae787/entities.c#L570