### PR TITLE
Clean up doctype handling in Beautiful Soup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 docs/_build
 test/large.html
 test/html5lib-tests
+__pycache__

--- a/src/html5_parser/soup.py
+++ b/src/html5_parser/soup.py
@@ -130,9 +130,9 @@ def parse(utf8_data, stack_size=16 * 1024, keep_doctype=False, return_root=True)
         utf8_data = utf8_data.encode('utf-8')
 
     def add_doctype(name, public_id, system_id):
-        public_id = (' PUBLIC ' + public_id + ' ') if public_id else ''
-        system_id = (' ' + system_id) if system_id else ''
-        soup.append(bs.Doctype('<!DOCTYPE {}{}{}>'.format(name, public_id, system_id)))
+        public_id = (' PUBLIC "' + public_id + '"') if public_id else ''
+        system_id = (' "' + system_id + '"') if system_id else ''
+        soup.append(bs.Doctype('{}{}{}'.format(name, public_id, system_id)))
 
     dt = add_doctype if keep_doctype and hasattr(bs, 'Doctype') else None
     root = html_parser.parse_and_build(

--- a/src/html5_parser/soup.py
+++ b/src/html5_parser/soup.py
@@ -130,9 +130,7 @@ def parse(utf8_data, stack_size=16 * 1024, keep_doctype=False, return_root=True)
         utf8_data = utf8_data.encode('utf-8')
 
     def add_doctype(name, public_id, system_id):
-        public_id = (' PUBLIC "' + public_id + '"') if public_id else ''
-        system_id = (' "' + system_id + '"') if system_id else ''
-        soup.append(bs.Doctype('{}{}{}'.format(name, public_id, system_id)))
+        soup.append(bs.Doctype.for_name_and_ids(name, public_id or None, system_id or None))
 
     dt = add_doctype if keep_doctype and hasattr(bs, 'Doctype') else None
     root = html_parser.parse_and_build(

--- a/test/adapt.py
+++ b/test/adapt.py
@@ -92,7 +92,10 @@ class AdaptTest(TestCase):
         root = parse(HTML, treebuilder='soup')
         soup = root.parent
         if soup_name != 'BeautifulSoup':
-            self.ae(DOCTYPE, str(soup.contents[0]))
+            # In BS 4+, Doctype instances only store their contents. They get
+            # formatted as `<!DOCTYPE {}>` when the whole soup is serialized.
+            parsed_doctype = str(soup).split('\n', 1)[0]
+            self.ae(DOCTYPE, parsed_doctype)
         self.ae(root.name, 'html')
         self.ae(dict(root.attrs), {'xml:lang': 'en', 'lang': 'en'})
         self.ae(dict(root.body.contents[-1].attrs), {'xml:lang': 'de'})

--- a/test/soup.py
+++ b/test/soup.py
@@ -68,3 +68,15 @@ class SoupTest(TestCase):
 
         for num in (1, 10, 100):
             self.assertLess(do_parse(num), 2)
+    
+    def test_doctype_stays_intact(self):
+        base = '\n<html><body><p>xxx</p></body></html>'
+        for dt in (
+                'html',
+                'html PUBLIC "-//W3C//DTD HTML 4.01//EN" '
+                '"http://www.w3.org/TR/html4/strict.dtd"'
+        ):
+            dt = '<!DOCTYPE {}>'.format(dt)
+            soup = parse(dt + base, return_root=False, keep_doctype=True)
+            parsed_doctype = str(soup).split('\n', 1)[0]
+            self.ae(dt, parsed_doctype)


### PR DESCRIPTION
When parsing with `treebuilder='soup'`, we were sending incorrect arguments to the Beautiful Soup `Doctype` constructor, which resulted in poor results if you tried to serialize the resulting soup later. You’d wind up with the original doctype declaration nested inside another declaration, like so:

```
<!DOCTYPE !<DOCTYPE>>
```

This adds some tests around the issue and slightly modifies the code so the right arguments are used. Fixes #18.