### PR TITLE
add compatibility with libxml2 2.12

### DIFF
--- a/src/as-libxml.c
+++ b/src/as-libxml.c
@@ -8,11 +8,13 @@
 
 #include <assert.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define NEEDS_SANITIZE_NAME 1
 #include "as-libxml.h"
 #include <libxml/tree.h>
 #include <libxml/dict.h>
+#include <libxml/parser.h>
 
 // Namespace constants, indexed by GumboNamespaceEnum.
 static const char* kLegalXmlns[] = {


### PR DESCRIPTION
The xmlParserVersion function was indirectly included via a maze of includes:

tree.h -> xmlmemory.h -> globals.h

the final header containing the definition of this function, but after an upstream refactor this is canonically defined in parser.h instead.

The latter header includes globals.h on old versions anyway.

stdlib.h was also required, but only indirectly included via libxml2's own includes.

Fixes: https://bugs.gentoo.org/917554